### PR TITLE
Deny secrets in namespace with annotation, if IAMRole is not set

### DIFF
--- a/pkg/rolevalidator/validator.go
+++ b/pkg/rolevalidator/validator.go
@@ -22,17 +22,17 @@ func NewRoleValidator(getter iam.ARNGetter, nsCache k8snamespace.NamespaceGetter
 }
 
 func (rv *RoleValidator) IsWhitelisted(role, namespace string) (bool, error) {
-	if role == "" { // Temporarily allow secrets without iamRole defined
-		return true, nil
-	}
-
 	ns, err := rv.nsCache.Get(namespace)
 	if err != nil {
 		return false, err
 	}
 
 	annotation, annotationFound := ns.Annotations[annotationName]
-	if !annotationFound { // An iamRole is set, but the namespace has no kube2iam annotation
+	if !annotationFound { // The namespace does not use kube2iam. We should not specify an IAMRole, but we dont prevent it
+		return true, nil
+	}
+
+	if role == "" { // Secrets must have a role defined if an annotation is found
 		return false, nil
 	}
 

--- a/pkg/rolevalidator/validator_test.go
+++ b/pkg/rolevalidator/validator_test.go
@@ -1,6 +1,7 @@
 package rolevalidator
 
 import (
+	"github.com/contentful-labs/k8s-secret-syncer/pkg/k8snamespace"
 	v1 "k8s.io/api/core/v1"
 	"testing"
 )
@@ -22,38 +23,66 @@ func (m *mockNSGetter) Get(nsName string) (*v1.Namespace, error) {
 	return ns, nil
 }
 
+type mockUnannottatedNSGetter struct {
+	annotation string
+}
+
+func (m *mockUnannottatedNSGetter) Get(nsName string) (*v1.Namespace, error) {
+	ns := &v1.Namespace{}
+	ns.Annotations = map[string]string{}
+
+	return ns, nil
+}
+
 func TestIsWhitelisted(t *testing.T) {
 	testCases := []struct {
-		role, annotation string
-		expectAllowed    bool
+		role          string
+		expectAllowed bool
+		getter        k8snamespace.NamespaceGetter
 	}{
 		{
 			role:          "role1",
-			annotation:    "[\"role1\"]",
 			expectAllowed: true,
+			getter: &mockNSGetter{
+				annotation: "[\"role1\"]",
+			},
 		},
 		{
 			role:          "role2",
-			annotation:    "[\"role1\", \"role2\"]",
 			expectAllowed: true,
+			getter: &mockNSGetter{
+				annotation: "[\"role1\", \"role2\"]",
+			},
 		},
 		{
 			role:          "role1",
-			annotation:    "[\"role2\"]",
 			expectAllowed: false,
+			getter: &mockNSGetter{
+				annotation: "[\"role2\"]",
+			},
+		},
+		{
+			role:          "role1",
+			expectAllowed: true,
+			getter:        &mockUnannottatedNSGetter{},
+		},
+		{
+			role:          "",
+			expectAllowed: false,
+			getter: &mockNSGetter{
+				annotation: "[\"role2\"]",
+			},
 		},
 	}
 
-	mng := &mockNSGetter{}
-	rv := NewRoleValidator(&mockARNGetter{}, mng)
 	for _, test := range testCases {
-		mng.annotation = test.annotation
-		isAllowed, err := rv.IsWhitelisted(test.role, test.annotation)
+		rv := NewRoleValidator(&mockARNGetter{}, test.getter)
+		isAllowed, err := rv.IsWhitelisted(test.role, "test")
 		if err != nil {
-			t.Errorf("got error with annotation %s, role %s: %s", test.annotation, test.role, err)
+			t.Errorf("got error with role %s: %s", test.role, err)
 		}
 		if isAllowed != test.expectAllowed {
-			t.Errorf("annotation %s, role %s, expected %t, got %t", test.annotation, test.role, test.expectAllowed, isAllowed)
+			t.Errorf("role %s, expected %t, got %t", test.role, test.expectAllowed, isAllowed)
 		}
 	}
 }


### PR DESCRIPTION
When the namespace has a kube2iam annotation, the secret MUST have a role specified. When the namespace has no kube2iam annotation, the secret can use no IAMRole, or any IAMRole.