### PR TITLE
Use environment variables instead of flags, disable leaderElection

### DIFF
--- a/pkg/rolevalidator/validator.go
+++ b/pkg/rolevalidator/validator.go
@@ -15,8 +15,9 @@ type RoleValidator struct {
 
 func NewRoleValidator(getter iam.ARNGetter, nsCache k8snamespace.NamespaceGetter, annotationName string) *RoleValidator {
 	return &RoleValidator{
-		arnGetter: getter,
-		nsCache:   nsCache,
+		arnGetter:      getter,
+		nsCache:        nsCache,
+		annotationName: annotationName,
 	}
 }
 


### PR DESCRIPTION
* Support configuring what annotation to look on the namespace to validate IAMRoles
* Remove LeaderElection parameter
* use environment variables instead of flags