### PR TITLE
Rely on SyncPeriod instead of retrying in the reconcile loop

### DIFF
--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -122,10 +122,10 @@ var _ = BeforeSuite(func(done Done) {
 
 	// +kubebuilder:scaffold:scheme
 
-	retryPeriod := 2 * time.Second
+	syncPeriod := 2 * time.Second
 	k8sManager, err = ctrl.NewManager(cfg, ctrl.Options{
-		Scheme:      scheme.Scheme,
-		RetryPeriod: &retryPeriod,
+		Scheme:     scheme.Scheme,
+		SyncPeriod: &syncPeriod,
 	})
 	Expect(err).ToNot(HaveOccurred())
 	Expect(k8sManager).ToNot(BeNil())
@@ -135,22 +135,22 @@ var _ = BeforeSuite(func(done Done) {
 	// create the secret for testing
 	MockSecretsOutput.SecretsPageOutput = &secretsmanager.ListSecretsOutput{
 		SecretList: []*secretsmanager.SecretListEntry{
-			&secretsmanager.SecretListEntry{
+			{
 				Name:            _s("random/aws/secret002"),
 				LastChangedDate: _t(time_now.AddDate(0, 0, -2)),
 				SecretVersionsToStages: map[string][]*string{
-					"002": []*string{
+					"002": {
 						_s("AWSCURRENT"),
 					},
 				},
-			}, &secretsmanager.SecretListEntry{
+			}, {
 				Name:            _s("random/aws/secret003"),
 				LastChangedDate: _t(time_now.AddDate(0, 0, -3)),
 				SecretVersionsToStages: map[string][]*string{
-					"005": []*string{
+					"005": {
 						_s("AWSCURRENT"),
 					},
-					"003": []*string{
+					"003": {
 						_s("AWSPREVIOUS"),
 					},
 				},

--- a/controllers/syncedsecret_controller.go
+++ b/controllers/syncedsecret_controller.go
@@ -77,7 +77,6 @@ const (
 func (r *SyncedSecretReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	var err error
 	var cs secretsv1.SyncedSecret
-	const defaultReconcileInterval = 120
 
 	defer r.updatePrometheus(r.sync_state)
 

--- a/controllers/syncedsecret_controller_test.go
+++ b/controllers/syncedsecret_controller_test.go
@@ -205,7 +205,7 @@ var _ = Describe("SyncedSecret Controller", func() {
 
 			MockSecretsOutput.SecretsPageOutput = &secretsmanager.ListSecretsOutput{
 				SecretList: []*secretsmanager.SecretListEntry{
-					&secretsmanager.SecretListEntry{
+					{
 						Name:            _s("random/aws/secret003"),
 						LastChangedDate: _t(time_now.AddDate(0, 0, -2)),
 						SecretVersionsToStages: map[string][]*string{
@@ -213,14 +213,14 @@ var _ = Describe("SyncedSecret Controller", func() {
 								_s("AWSCURRENT"),
 							},
 						},
-					}, &secretsmanager.SecretListEntry{
+					}, {
 						Name:            _s("random/aws/secret003"),
 						LastChangedDate: _t(time_now.AddDate(0, 0, -1)),
 						SecretVersionsToStages: map[string][]*string{
-							"005": []*string{
+							"005": {
 								_s("AWSPREVIOUS"),
 							},
-							"006": []*string{
+							"006": {
 								_s("AWSCURRENT"),
 							},
 						},


### PR DESCRIPTION
Trying to find why the reconcile loop does not always retry when it encounters an error, I found that the controllerManager takes a SyncPeriod argument, which we should be able to use to ensure the reconcile loop is run regularly for every resource - https://github.com/kubernetes-sigs/cluster-api/issues/748

Also we seem to only return RequeueAfter: r.ReconcileInterval  on success in the reconcile loop, so by default it would only reconcile every 10h on failure?