### PR TITLE
add documentation generator for the API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ out/
 
 # go binary built with `go build -a -o manager main.go`
 manager
+
+# jekyll site output
+docs/_site
+docs/Gemfile*

--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ endif
 
 docs: docs-gen
 	docker pull asciidoctor/docker-asciidoctor
-	$(GEN_DOCS) --config docs/_config/config.yaml --source-path "./api/v1/" --renderer asciidoctor --templates-dir docs/_template/asciidoctor/ --output-path docs/api.adoc
+	$(GEN_DOCS) --config docs/_doc.yaml --source-path "./api/v1/" --renderer asciidoctor --templates-dir docs/_template/asciidoctor/ --output-path docs/api.adoc
 	$(ASCII_DOC) asciidoctor api.adoc -a stylesheet! -b xhtml5 -o api.md -s
 	rm docs/api.adoc
 

--- a/api/v1/syncedsecret_types.go
+++ b/api/v1/syncedsecret_types.go
@@ -22,19 +22,27 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
+// SecretRef secret ref
 type SecretRef struct {
+	// Secret Name
 	Name *string `json:"name"`
 }
 
+// DataFrom data from
 type DataFrom struct {
+	// SecretRef
 	SecretRef *SecretRef `json:"secretRef,omitempty"`
 }
 
+// SecretKeyRef secret key ref
 type SecretKeyRef struct {
+	// Secret Name
 	Name *string `json:"name"`
-	Key  *string `json:"key"`
+	// Secret Key
+	Key *string `json:"key"`
 }
 
+// ValueFrom value from
 type ValueFrom struct {
 	// SecretRef
 	// +optional
@@ -49,7 +57,9 @@ type ValueFrom struct {
 	Template *string `json:"template,omitempty"`
 }
 
+// SecretField secret field
 type SecretField struct {
+	// secret Name
 	Name *string `json:"name"`
 
 	// Value
@@ -94,6 +104,7 @@ type SyncedSecretStatus struct {
 	SecretHash string `json:"generatedSecretHash,omitempty"`
 }
 
+// +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,10 @@
+plugins:
+  - jekyll-relative-links
+relative_links:
+  enabled: true
+  collections: true
+include:
+  - api.md
+  - development.md
+
+theme: jekyll-theme-cayman

--- a/docs/_doc.yaml
+++ b/docs/_doc.yaml
@@ -1,0 +1,9 @@
+processor:
+  ignoreTypes:
+    - "(SyncedSecret)List$"
+  ignoreFields:
+    - "status$"
+    - "TypeMeta$"
+
+render:
+  kubernetesVersion: 1.16

--- a/docs/_template/asciidoctor/gv_details.tpl
+++ b/docs/_template/asciidoctor/gv_details.tpl
@@ -1,0 +1,19 @@
+{{- define "gvDetails" -}}
+{{- $gv := . -}}
+[id="{{ asciidocGroupVersionID $gv | asciidocRenderAnchorID }}"]
+== {{ $gv.GroupVersionString }}
+
+{{ $gv.Doc }}
+
+{{- if $gv.Kinds  }}
+.Resource Types
+{{- range $gv.Kinds }}
+- {{ $gv.TypeForKind . | asciidocRenderTypeLink }}
+{{- end }}
+{{ end }}
+
+{{ range $gv.SortedTypes }}
+{{ template "type" . }}
+{{ end }}
+
+{{- end -}}

--- a/docs/_template/asciidoctor/gv_list.tpl
+++ b/docs/_template/asciidoctor/gv_list.tpl
@@ -1,0 +1,19 @@
+{{- define "gvList" -}}
+{{- $groupVersions := . -}}
+
+// Generated documentation. Please do not edit.
+:anchor_prefix: k8s-api
+
+[id="{p}-api-reference"]
+= API Reference
+
+.Packages
+{{- range $groupVersions }}
+- {{ asciidocRenderGVLink . }}
+{{- end }}
+
+{{ range $groupVersions }}
+{{ template "gvDetails" . }}
+{{ end }}
+
+{{- end -}}

--- a/docs/_template/asciidoctor/type.tpl
+++ b/docs/_template/asciidoctor/type.tpl
@@ -1,0 +1,36 @@
+{{- define "type" -}}
+{{- $type := . -}}
+{{- if asciidocShouldRenderType $type -}}
+
+[id="{{ asciidocTypeID $type | asciidocRenderAnchorID }}"]
+=== {{ $type.Name  }} {{ if $type.IsAlias }}({{ asciidocRenderTypeLink $type.UnderlyingType  }}) {{ end }}
+
+{{ $type.Doc }}
+
+{{ if $type.References -}}
+.Appears In:
+****
+{{- range $type.SortedReferences }}
+- {{ asciidocRenderTypeLink . }}
+{{- end }}
+****
+{{- end }}
+
+{{ if $type.Members -}}
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+{{ if $type.GVK -}}
+| *`apiVersion`* __string__ | `{{ $type.GVK.Group }}/{{ $type.GVK.Version }}`
+| *`kind`* __string__ | `{{ $type.GVK.Kind }}`
+{{ end -}}
+
+{{ range $type.Members -}}
+| *`{{ .Name  }}`* __{{ asciidocRenderType .Type }}__ | {{ template "type_members" . }}
+{{ end -}}
+|===
+{{ end -}}
+
+{{- end -}}
+'''
+{{- end -}}

--- a/docs/_template/asciidoctor/type_members.tpl
+++ b/docs/_template/asciidoctor/type_members.tpl
@@ -1,0 +1,8 @@
+{{- define "type_members" -}}
+{{- $field := . -}}
+{{- if eq $field.Name "metadata" -}}
+Refer to Kubernetes API documentation for fields of `metadata`.
+{{ else -}}
+{{ $field.Doc }}
+{{- end -}}
+{{- end -}}

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,393 @@
+<div id="preamble">
+<div class="sectionbody">
+<div class="ulist">
+<div class="title">Packages</div>
+<ul>
+<li>
+<p><a href="#k8s-api-secrets-contentful-com-v1">secrets.contentful.com/v1</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="k8s-api-secrets-contentful-com-v1">secrets.contentful.com/v1</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>Package v1 contains API Schema definitions for the secrets v1 API group</p>
+</div>
+<div class="ulist">
+<div class="title">Resource Types</div>
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-contentful-labs-k8s-secret-syncer-api-v1-syncedsecret">SyncedSecret</a></p>
+</li>
+</ul>
+</div>
+<div class="sect2">
+<h3 id="k8s-api-github-com-contentful-labs-k8s-secret-syncer-api-v1-datafrom">DataFrom</h3>
+<div class="paragraph">
+<p>DataFrom data from</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-contentful-labs-k8s-secret-syncer-api-v1-syncedsecretspec">SyncedSecretSpec</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;"/>
+<col style="width: 75%;"/>
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>secretRef</code></strong> <em><a href="#k8s-api-github-com-contentful-labs-k8s-secret-syncer-api-v1-secretref">SecretRef</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>SecretRef</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+<hr/>
+</div>
+<div class="sect2">
+<h3 id="k8s-api-github-com-contentful-labs-k8s-secret-syncer-api-v1-secretfield">SecretField</h3>
+<div class="paragraph">
+<p>SecretField secret field</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-contentful-labs-k8s-secret-syncer-api-v1-syncedsecretspec">SyncedSecretSpec</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;"/>
+<col style="width: 75%;"/>
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>name</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>secret Name</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>value</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Value</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>valueFrom</code></strong> <em><a href="#k8s-api-github-com-contentful-labs-k8s-secret-syncer-api-v1-valuefrom">ValueFrom</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>ValueFrom</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+<hr/>
+</div>
+<div class="sect2">
+<h3 id="k8s-api-github-com-contentful-labs-k8s-secret-syncer-api-v1-secretkeyref">SecretKeyRef</h3>
+<div class="paragraph">
+<p>SecretKeyRef secret key ref</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-contentful-labs-k8s-secret-syncer-api-v1-valuefrom">ValueFrom</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;"/>
+<col style="width: 75%;"/>
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>name</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Secret Name</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>key</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Secret Key</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+<hr/>
+</div>
+<div class="sect2">
+<h3 id="k8s-api-github-com-contentful-labs-k8s-secret-syncer-api-v1-secretref">SecretRef</h3>
+<div class="paragraph">
+<p>SecretRef secret ref</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-contentful-labs-k8s-secret-syncer-api-v1-datafrom">DataFrom</a></p>
+</li>
+<li>
+<p><a href="#k8s-api-github-com-contentful-labs-k8s-secret-syncer-api-v1-valuefrom">ValueFrom</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;"/>
+<col style="width: 75%;"/>
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>name</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Secret Name</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+<hr/>
+</div>
+<div class="sect2">
+<h3 id="k8s-api-github-com-contentful-labs-k8s-secret-syncer-api-v1-syncedsecret">SyncedSecret</h3>
+<div class="paragraph">
+<p>SyncedSecret is the Schema for the SyncedSecrets API</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;"/>
+<col style="width: 75%;"/>
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>apiVersion</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><code>secrets.contentful.com/v1</code></p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>kind</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><code>SyncedSecret</code></p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>metadata</code></strong> <em><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#objectmeta-v1-meta">ObjectMeta</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Refer to Kubernetes API documentation for fields of <code>metadata</code>.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>spec</code></strong> <em><a href="#k8s-api-github-com-contentful-labs-k8s-secret-syncer-api-v1-syncedsecretspec">SyncedSecretSpec</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"></div></td>
+</tr>
+</tbody>
+</table>
+<hr/>
+</div>
+<div class="sect2">
+<h3 id="k8s-api-github-com-contentful-labs-k8s-secret-syncer-api-v1-syncedsecretspec">SyncedSecretSpec</h3>
+<div class="paragraph">
+<p>SyncedSecretSpec defines the desired state of SyncedSecret</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-contentful-labs-k8s-secret-syncer-api-v1-syncedsecret">SyncedSecret</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;"/>
+<col style="width: 75%;"/>
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>secretMetadata</code></strong> <em><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#objectmeta-v1-meta">ObjectMeta</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Secret Metadata</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>IAMRole</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>IAMRole</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>data</code></strong> <em><a href="#k8s-api-github-com-contentful-labs-k8s-secret-syncer-api-v1-secretfield">SecretField</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Data</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>dataFrom</code></strong> <em><a href="#k8s-api-github-com-contentful-labs-k8s-secret-syncer-api-v1-datafrom">DataFrom</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>DataFrom</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+<hr/>
+<hr/>
+</div>
+<div class="sect2">
+<h3 id="k8s-api-github-com-contentful-labs-k8s-secret-syncer-api-v1-valuefrom">ValueFrom</h3>
+<div class="paragraph">
+<p>ValueFrom value from</p>
+</div>
+<div class="sidebarblock">
+<div class="content">
+<div class="title">Appears In:</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#k8s-api-github-com-contentful-labs-k8s-secret-syncer-api-v1-secretfield">SecretField</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;"/>
+<col style="width: 75%;"/>
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Field</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>secretRef</code></strong> <em><a href="#k8s-api-github-com-contentful-labs-k8s-secret-syncer-api-v1-secretref">SecretRef</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>SecretRef</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>secretKeyRef</code></strong> <em><a href="#k8s-api-github-com-contentful-labs-k8s-secret-syncer-api-v1-secretkeyref">SecretKeyRef</a></em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>SecretKeyRef</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong><code>template</code></strong> <em>string</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Template</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+<hr/>
+</div>
+</div>
+</div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,162 @@
+# K8s-secret-syncer
+
+K8s-Secrets-syncer is a [Kubernetes operator](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/) developed
+using [the Kubebuilder framework](https://github.com/kubernetes-sigs/kubebuilder) that keeps the values of Kubernetes
+Secrets synchronised to secrets in AWS Secrets Manager.
+
+This mapping is described in a Kubernetes custom resource called SyncedSecret. The operator polls AWS for changes in
+secret values at regular intervals, and upon detecting changes, updates the Kubernetes Secrets.
+
+__WARNING__: updating the value of a secret in AWS SecretsManager will override secrets in Kubernetes, therefore
+ can be a destructive action.
+
+## Comparison to existing projects
+
+K8s-secret-syncer is similar to other projects such as:
+ * [Kubernetes external secrets](https://github.com/godaddy/kubernetes-external-secrets)
+ * [AWS secret operator](https://github.com/mumoshu/aws-secret-operator)
+
+K8s-secret-syncer improves on this approach: 
+ * uses [caching](#caching) to only retrieve the value of secrets when they have changed, substantially reducing
+ [costs](https://aws.amazon.com/secrets-manager/pricing/) when syncing a large number of secrets.
+ * enables sophisticated access control to secrets in AWS SecretsManager using IAM roles - see our
+ [security model](#security-model)
+ * supports [templated fields](#templated-fields) for Kubernetes secrets - enabling the use of values from multiple AWS
+ SecretsManager secrets in one Kubernetes Secret
+
+## Defining mapping between an AWS SecretsManager secret and a Kubernetes Secret
+
+The following resource will map the AWS Secret ```secretsyncer/secret/sample``` to the Kubernetes Secret
+```demo-service-secret```, and copy all key-value pairs from the AWS SecretsManager secret to the  Kubernetes secret For
+ this example, the AWS SecretsManager secret needs to be a valid JSON consisting only of key-value pairs.
+
+To access the secrets, k8s-secret-syncer will assume the role ```iam_role``` to poll the secret. Note: that role must be
+ assumed by the Kubernetes cluster/node where the operator runs, eg part of the kube2iam annotation on the namespace.
+
+```
+apiVersion: secrets.contentful.com/v1
+kind: SyncedSecret
+metadata:
+  name: demo-service-secret
+  namespace: secret-sync
+spec:
+  IAMRole: iam_role
+  dataFrom:
+    secretRef:
+      name: secretsyncer/secret/sample
+```
+
+If you only need to retrieve select keys in a single AWS secret, or multiple keys from different AWS secrets, you
+can use the following syntax:
+
+```
+apiVersion: secrets.contentful.com/v1
+kind: SyncedSecret
+metadata:
+  name: demo-service-secret
+  namespace: secret-sync
+spec:
+  IAMRole: iam_role
+  data:
+    # Sets the key mysql_user for the Kubernetes Secret "demo-service-secret" to "contentful"
+    - name: mysql_user
+      value: "contentful"
+    # Takes the value for key "password" from the Secrets Manager secret "mysql", assign to the
+    # key "mysql_pw" of the Kubernetes secret "demo-service-secret"
+    - name: mysql_pw
+      secretKeyRef:
+        name: mysql
+        key: password
+    - name: datadog_access_key
+      secretKeyRef:
+        name: datadog
+        key: access_key
+```
+
+You can also chose to store non-JSON values in AWS Secret Manager, which might be more convenient for data such
+as certificates.
+
+```
+apiVersion: secrets.contentful.com/v1
+kind: SyncedSecret
+metadata:
+  name: demo-service-secret
+  namespace: secret-sync
+spec:
+  IAMRole: iam_role
+  data:
+    # Sets the key ssl-certificate for the Kubernetes Secret "demo-service-secret"
+    # to the value of the secret "apache/ssl-cert"
+    - name: ssl-certificate
+      valueFrom:
+        secretRef:
+          name: apache/ssl-cert
+```
+
+## [Templated fields](#templated-fields)
+
+K8s-secret-syncer supports templated fields. This allows, for example, to iterate over a list of secrets that
+share the same tag, to output a configuration file, such as in the following example:
+
+```
+apiVersion: secrets.contentful.com/v1
+kind: SyncedSecret
+metadata:
+  name: pgbouncer.txt
+  namespace: secret-sync
+spec:
+  IAMRole: iam_role
+  data:
+    - name: pgbouncer-hosts
+      valueFrom:
+        template: |
+          {{- $cfg := "" -}}
+          {{- range $secretID, $_ := filterByTagKey .Secrets "tag1" -}}
+            {{- $secretValue := getSecretValueMap $secretID -}}
+            {{- $cfg = printf "%shost=%s user=%s password=%s\n" $cfg $secretValue.host $secretValue.user $secretValue.password -}}
+          {{- end -}}
+          {{- $cfg -}}
+```
+
+This iterates over all secrets k8s-secret-syncer has access to, select those that have the tag "tag1" set,
+and for each of these, add a configuration line to $cfg. $cfg is then assigned to the key "pgbouncer-hosts" of
+the Kubernetes secret pgbouncer.txt.
+
+The template is a [Go template](https://golang.org/pkg/text/template/) with the following elements defined:
+ * .Secrets - a map containing all listed secrets (without their value)
+ * filterByTagKey - a helper function to filter the secrets by tag
+ * getSecretValue - will retrieve the raw value of a Secret in SecretsManager, given its secret ID
+ * getSecretValueMap - will retrieve the value of a Secret in SecretsManager that contains a JSON, given its secret ID -
+ as a map
+
+## [Caching](#caching)
+
+K8s-secret-syncer maintains both the list of AWS Secrets as well as their values in cache. The list is updated every
+`POLL_INTERVAL_SEC`, and values are retrieved whenever their VersionID changed.
+
+## [Security model](#security-model)
+
+By default, k8s-secret-syncer will use the Kubernetes node's IAM role to list and retrieve the secrets. However, when
+synced secrets have an IAMRole field defined, k8s-secret-syncer will assume that role before retrieving the secret. This
+implies that the role specified by IAMRole can be assumed by the role of the Kubernetes node secret-syncer runs on.
+
+To ensure a specific namespace only has access to the secrets it needs to, k8s-secret-syncer will use the
+"iam.amazonaws.com/allowed-roles" annotation on the namespace (originally used by kube2iam) to validate that this
+role can be assumed for that namespace.
+
+The secret synchronisation will be allowed if:
+ * the annotation is set on the namespace and contains the secrets IAMRole
+ * no annotation is set on the namespace and the secret has a IAMRole set
+ * no annotation is set on the namespace and the secret has no IAMRole set
+
+The secret sync will be denied if:
+ * the annotation is set on the namespace and does not contains the secrets IAMRole
+ * the annotation is set on the namespace and the secret has no IAMRole set
+
+## Local development
+
+Please refer to [local-development documentation](docs/development.md)
+
+## Examples
+
+See [sample configurations](config/samples)


### PR DESCRIPTION
docs: add make step for docs generation (`make docs`) https://github.com/contentful-labs/k8s-secret-syncer/pull/20/files#diff-b67911656ef5d18c4ae36cb6741b7965R102

 * uses https://github.com/elastic/crd-ref-docs/ to generate docs
 * this generates into asciidoc using the template in docs/_template and config in docs/_doc.yaml
* docs/_config.yml contains jekyll config for gh-pages hosting
* generates docs from the `api/v1` package, into `docs` folder which in turn will be a jekyll site. It also copies README.md as the index for the site. 