### PR TITLE
Sync state is not initialised in SetupWithManager

### DIFF
--- a/controllers/syncedsecret_controller.go
+++ b/controllers/syncedsecret_controller.go
@@ -208,6 +208,7 @@ func (r *SyncedSecretReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		}
 	}()
 
+	r.sync_state = map[string]bool{}
 	r.gauges = map[string]prometheus.Gauge{
 		"secret_sync_success": prometheus.NewGauge(
 			prometheus.GaugeOpts{


### PR DESCRIPTION
We do initalise r.sync_state correctly in the test suite, but forgot to do it in SetupWithManager.