### PR TITLE
fix: circleci publish-tag workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,8 +76,14 @@ workflows:
   version: 2
   flow:
     jobs:
-      - test
-      - build
+      - test:
+          filters:
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*(-.*)*
+      - build:
+          filters:
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*(-.*)*
       - publish-branch:
           requires:
             - build


### PR DESCRIPTION
includes the build and test jobs for publish-tag workflow

[According to circleci docs](https://circleci.com/docs/2.0/configuration-reference/#tags):
> Additionally, if a job requires any other jobs (directly or indirectly), you must specify tag filters for those jobs