### PR TITLE
feat: enable secret types

### DIFF
--- a/api/v1/syncedsecret_types.go
+++ b/api/v1/syncedsecret_types.go
@@ -17,6 +17,7 @@ package v1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
@@ -104,6 +105,8 @@ type SyncedSecret struct {
 
 	Spec   SyncedSecretSpec   `json:"spec,omitempty"`
 	Status SyncedSecretStatus `json:"status,omitempty"`
+
+	Type corev1.SecretType `json:"type,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1/syncedsecret_types.go
+++ b/api/v1/syncedsecret_types.go
@@ -16,8 +16,8 @@ limitations under the License.
 package v1
 
 import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!

--- a/api/v1/syncedsecret_types.go
+++ b/api/v1/syncedsecret_types.go
@@ -81,6 +81,10 @@ type SyncedSecretSpec struct {
 	// DataFrom
 	// +optional
 	DataFrom *DataFrom `json:"dataFrom,omitempty"`
+
+	// Type
+	// +optional
+	Type corev1.SecretType `json:"type,omitempty"`
 }
 
 // SyncedSecretStatus defines the observed state of SyncedSecret
@@ -105,8 +109,6 @@ type SyncedSecret struct {
 
 	Spec   SyncedSecretSpec   `json:"spec,omitempty"`
 	Status SyncedSecretStatus `json:"status,omitempty"`
-
-	Type corev1.SecretType `json:"type,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/config/crd/bases/secrets.contentful.com_syncedsecrets.yaml
+++ b/config/crd/bases/secrets.contentful.com_syncedsecrets.yaml
@@ -92,6 +92,9 @@ spec:
             secretMetadata:
               description: Secret Metadata
               type: object
+            type:
+              description: Type
+              type: string
           type: object
         status:
           description: SyncedSecretStatus defines the observed state of SyncedSecret
@@ -107,8 +110,6 @@ spec:
           required:
           - currentVersionID
           type: object
-        type:
-          type: string
       type: object
   version: v1
   versions:

--- a/config/crd/bases/secrets.contentful.com_syncedsecrets.yaml
+++ b/config/crd/bases/secrets.contentful.com_syncedsecrets.yaml
@@ -107,6 +107,8 @@ spec:
           required:
           - currentVersionID
           type: object
+        type:
+          type: string
       type: object
   version: v1
   versions:

--- a/config/samples/secrets_v1_syncedsecret_specified_type.yaml
+++ b/config/samples/secrets_v1_syncedsecret_specified_type.yaml
@@ -1,0 +1,16 @@
+apiVersion: secrets.contentful.com/v1
+kind: SyncedSecret
+type: kubernetes.io/dockerconfigjson
+metadata:
+  name: syncedsecret-sample-ks
+  namespace: kube-secret-syncer
+spec:
+  secretMetadata:
+    name: demo-service-secret
+    namespace: kube-secret-syncer
+    annotations:
+      randomkey: randomval
+  data:
+    DB_NAME: database_name
+    DB_PASS: database_pass
+  secretid: secretsyncer/secret/sample

--- a/config/samples/secrets_v1_syncedsecret_specified_type.yaml
+++ b/config/samples/secrets_v1_syncedsecret_specified_type.yaml
@@ -1,10 +1,10 @@
 apiVersion: secrets.contentful.com/v1
 kind: SyncedSecret
-type: kubernetes.io/dockerconfigjson
 metadata:
   name: syncedsecret-sample-ks
   namespace: kube-secret-syncer
 spec:
+  type: kubernetes.io/dockerconfigjson
   secretMetadata:
     name: demo-service-secret
     namespace: kube-secret-syncer

--- a/pkg/k8ssecret/secret.go
+++ b/pkg/k8ssecret/secret.go
@@ -154,8 +154,8 @@ func GenerateK8SSecret(
 	}
 
 	secretType := corev1.SecretTypeOpaque
-	if cs.Type != "" {
-		secretType = cs.Type
+	if cs.Spec.Type != "" {
+		secretType = cs.Spec.Type
 	}
 
 	secret := &corev1.Secret{

--- a/pkg/k8ssecret/secret.go
+++ b/pkg/k8ssecret/secret.go
@@ -153,7 +153,6 @@ func GenerateK8SSecret(
 		}
 	}
 
-
 	secretType := corev1.SecretTypeOpaque
 	if cs.Type != "" {
 		secretType = cs.Type

--- a/pkg/k8ssecret/secret.go
+++ b/pkg/k8ssecret/secret.go
@@ -153,13 +153,19 @@ func GenerateK8SSecret(
 		}
 	}
 
+
+	secretType := corev1.SecretTypeOpaque
+	if cs.Type != "" {
+		secretType = cs.Type
+	}
+
 	secret := &corev1.Secret{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
 			Kind:       "Secret",
 		},
 		ObjectMeta: secretMeta,
-		Type:       "Opaque",
+		Type:       secretType,
 		Data:       data,
 	}
 

--- a/pkg/k8ssecret/secret_test.go
+++ b/pkg/k8ssecret/secret_test.go
@@ -160,7 +160,7 @@ func TestGenerateSecret(t *testing.T) {
 					"field2": []byte("value2"),
 				},
 			},
-		},{
+		}, {
 			name: "it should support fields with a hardcoded value for Secret Type",
 			have: have{
 				SyncedSecret: secretsv1.SyncedSecret{

--- a/pkg/k8ssecret/secret_test.go
+++ b/pkg/k8ssecret/secret_test.go
@@ -160,6 +160,58 @@ func TestGenerateSecret(t *testing.T) {
 					"field2": []byte("value2"),
 				},
 			},
+		},{
+			name: "it should support fields with a hardcoded value for Secret Type",
+			have: have{
+				SyncedSecret: secretsv1.SyncedSecret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret-name",
+						Namespace: "secret-namespace",
+					},
+					Spec: secretsv1.SyncedSecretSpec{
+						SecretMetadata: metav1.ObjectMeta{
+							Name:      "secret-name",
+							Namespace: "secret-namespace",
+							Annotations: map[string]string{
+								"randomkey": "random/string",
+							},
+						},
+						Data: []*secretsv1.SecretField{
+							{
+								Name:  _s("foo"),
+								Value: _s("bar"),
+							},
+							{
+								Name:  _s("field2"),
+								Value: _s("value2"),
+							},
+						},
+						IAMRole: _s("iam_role"),
+					},
+					Type: "kubernetes.io/dockerconfigjson",
+				},
+				err:               nil,
+				cachedSecrets:     secretsmanager.Secrets{"cachedSecret1": {}, "cachedSecret2": {}},
+				secretValueGetter: mockgetSecretValue,
+			},
+			want: &corev1.Secret{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Secret",
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secret-name",
+					Namespace: "secret-namespace",
+					Annotations: map[string]string{
+						"randomkey": "random/string",
+					},
+				},
+				Type: "kubernetes.io/dockerconfigjson",
+				Data: map[string][]byte{
+					"foo":    []byte("bar"),
+					"field2": []byte("value2"),
+				},
+			},
 		},
 		{
 			name: "it should support references to a single field in an AWS Secret",

--- a/pkg/k8ssecret/secret_test.go
+++ b/pkg/k8ssecret/secret_test.go
@@ -160,7 +160,8 @@ func TestGenerateSecret(t *testing.T) {
 					"field2": []byte("value2"),
 				},
 			},
-		}, {
+		},
+		{
 			name: "it should support fields with a hardcoded value for Secret Type",
 			have: have{
 				SyncedSecret: secretsv1.SyncedSecret{
@@ -187,8 +188,8 @@ func TestGenerateSecret(t *testing.T) {
 							},
 						},
 						IAMRole: _s("iam_role"),
+						Type:    "kubernetes.io/dockerconfigjson",
 					},
-					Type: "kubernetes.io/dockerconfigjson",
 				},
 				err:               nil,
 				cachedSecrets:     secretsmanager.Secrets{"cachedSecret1": {}, "cachedSecret2": {}},


### PR DESCRIPTION
The original code assume that all synced secrets would be `Opaque`.
This change allows the user to add the correct key to the `SyncedSecret` to set the `SecretType`