### PR TITLE
Spread start of operators more evenly across the POLL_INTERVAL

### DIFF
--- a/main.go
+++ b/main.go
@@ -195,7 +195,7 @@ func realMain() int {
 	// Introduce artificial startup delay so that all controllers do not start
 	// polling SecretsManager at the same time
 	r1 := rand.New(rand.NewSource(time.Now().UnixNano()))
-	initialDelayS := time.Duration(r1.Intn(60)) * time.Second
+	initialDelayS := time.Duration(r1.Intn(int(pollInterval / time.Second))) * time.Second
 	time.Sleep(initialDelayS)
 
 	if err = r.SetupWithManager(mgr); err != nil {


### PR DESCRIPTION
When running a large number of kube-secret-operators and restarting them all at the same time, it's possible they might all try to ListSecrets at the same time from Secrets Manager. Depending on the number of secrets they might sometimes get rate limited. This should spread the ListSecrets more evenly.