### PR TITLE
Default search role

### DIFF
--- a/controllers/syncedsecret_controller.go
+++ b/controllers/syncedsecret_controller.go
@@ -59,6 +59,8 @@ type SyncedSecretReconciler struct {
 	Log           logr.Logger
 	wg            sync.WaitGroup
 
+	DefaultSearchRole string
+
 	gauges     map[string]prometheus.Gauge
 	sync_state map[string]bool
 }
@@ -227,7 +229,7 @@ func (r *SyncedSecretReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		metrics.Registry.MustRegister(metric)
 	}
 
-	if r.poller, err = secretsmanager.New(r.PollInterval, errs, r.GetSMClient); err != nil {
+	if r.poller, err = secretsmanager.New(r.PollInterval, errs, r.GetSMClient, r.DefaultSearchRole); err != nil {
 		return err
 	}
 

--- a/main.go
+++ b/main.go
@@ -123,6 +123,9 @@ func realMain() int {
 		metricsAddr = ":8080"
 	}
 
+	// empty string default is what we want
+	defaultSearchRole := os.Getenv("POLL_DEFAULT_SEARCH_ROLE")
+
 	annotationName := os.Getenv("NS_ANNOTATION")
 	if annotationName == "" {
 		annotationName = "iam.amazonaws.com/allowed-roles"
@@ -183,13 +186,14 @@ func realMain() int {
 	roleValidator := rolevalidator.NewRoleValidator(arnClient, nsCache, annotationName)
 
 	r := &controllers.SyncedSecretReconciler{
-		Client:        mgr.GetClient(),
-		Ctx:           ctx,
-		Log:           logger.WithName("controllers").WithName("SyncedSecret"),
-		Sess:          session.New(Retry5Cfg),
-		GetSMClient:   smsvcfactory.getSMSVC,
-		RoleValidator: roleValidator,
-		PollInterval:  pollInterval,
+		Client:            mgr.GetClient(),
+		Ctx:               ctx,
+		Log:               logger.WithName("controllers").WithName("SyncedSecret"),
+		Sess:              session.New(Retry5Cfg),
+		GetSMClient:       smsvcfactory.getSMSVC,
+		DefaultSearchRole: defaultSearchRole,
+		RoleValidator:     roleValidator,
+		PollInterval:      pollInterval,
 	}
 
 	// Introduce artificial startup delay so that all controllers do not start


### PR DESCRIPTION
This is a hack until we can more properly implement support for multiple AWS accounts.

kube-secret-syncer already works with multiple AWS accounts, since you can specify an arbitrary IAMRole for each individual SyncedSecret, and as long as it is able to assume it, it can do its job; unfortunately this doesn't cover the `filterByTagKey` option - for this, currently kube-secret-syncer is only able to list secrets visible to its default identity.

This change allows you to specify an alternate IAM role for this listing, which solves our internal use case for now, but we want to revisit this at a later date.