### PR TITLE
Remove random wait at controller startup

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,7 +18,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"os"
 	"strconv"
 	"time"
@@ -194,12 +193,6 @@ func realMain() int {
 		RoleValidator:     roleValidator,
 		PollInterval:      pollInterval,
 	}
-
-	// Introduce artificial startup delay so that all controllers do not start
-	// polling SecretsManager at the same time
-	r1 := rand.New(rand.NewSource(time.Now().UnixNano()))
-	initialDelayS := time.Duration(r1.Intn(int(pollInterval/time.Second))) * time.Second
-	time.Sleep(initialDelayS)
 
 	if err = r.SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "SyncedSecret")


### PR DESCRIPTION
# What is changing and why?

Remove the initial random waiting period before the controller starts polling the AWS API. 

This was originally added because some users may run multiple instances of this controller, and if they all started up at the same time, they may exhaust the AWS SecretsManager API rate limits, which used to be much lower. The API ratelimits are now considerably elevated, plus there is an expontential backoff retry mechanism in place. 
In case someone wants to orchestrate the startup of multiple controllers, they should do it in the kubernetes manifests. 

This change also makes it quicker to develop kube-secret-syncer (because there is no waiting time for logs to appear). 