### PR TITLE
remove unnecessary logging

### DIFF
--- a/controllers/syncedsecret_controller.go
+++ b/controllers/syncedsecret_controller.go
@@ -183,7 +183,6 @@ func (r *SyncedSecretReconciler) updateK8SSecret(ctx context.Context, cs *secret
 		return nil, err
 	}
 
-	r.Log.Info("Updating K8S Secret", "K8SSecret", secret.ObjectMeta, "secretSize", k8ssecret.SecretLength(secret))
 	return secret, nil
 }
 


### PR DESCRIPTION
Accidentally there was a logline every time an Update command was sent to the k8s api, even if there was no change to the secret. this creates a lot of unnecessary loglines and actually makes it hared to see when the secret was changed. remove this. 