### PR TITLE
feat: [MEC-1673] - update example CRD

### DIFF
--- a/examples/apiextensions.k8s.io_v1beta1_customresourcedefinition_syncedsecrets.secrets.contentful.com.yaml
+++ b/examples/apiextensions.k8s.io_v1beta1_customresourcedefinition_syncedsecrets.secrets.contentful.com.yaml
@@ -1,9 +1,9 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+---
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.4
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.17.1
   name: syncedsecrets.secrets.contentful.com
 spec:
   group: secrets.contentful.com
@@ -13,101 +13,124 @@ spec:
     plural: syncedsecrets
     singular: syncedsecret
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: SyncedSecret is the Schema for the SyncedSecrets API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: SyncedSecretSpec defines the desired state of SyncedSecret
-          properties:
-            IAMRole:
-              description: IAMRole
-              type: string
-            data:
-              description: Data
-              items:
-                properties:
-                  name:
-                    type: string
-                  value:
-                    description: Value
-                    type: string
-                  valueFrom:
-                    description: ValueFrom
-                    properties:
-                      secretKeyRef:
-                        description: SecretKeyRef
-                        properties:
-                          key:
-                            type: string
-                          name:
-                            type: string
-                        required:
-                        - key
-                        - name
-                        type: object
-                      secretRef:
-                        description: SecretRef
-                        properties:
-                          name:
-                            type: string
-                        required:
-                        - name
-                        type: object
-                      template:
-                        description: Template
-                        type: string
-                    type: object
-                required:
-                - name
-                type: object
-              type: array
-            dataFrom:
-              description: DataFrom
-              properties:
-                secretRef:
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: SyncedSecret is the Schema for the SyncedSecrets API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SyncedSecretSpec defines the desired state of SyncedSecret
+            properties:
+              AWSAccountID:
+                description: AWSAccountID
+                type: string
+              IAMRole:
+                description: IAMRole
+                type: string
+              data:
+                description: Data
+                items:
                   properties:
                     name:
                       type: string
+                    value:
+                      description: Value
+                      type: string
+                    valueFrom:
+                      description: ValueFrom
+                      properties:
+                        secretKeyRef:
+                          description: SecretKeyRef
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              type: string
+                          required:
+                          - key
+                          - name
+                          type: object
+                        secretRef:
+                          description: SecretRef
+                          properties:
+                            name:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        template:
+                          description: Template
+                          type: string
+                      type: object
                   required:
                   - name
                   type: object
-              type: object
-            secretMetadata:
-              description: Secret Metadata
-              type: object
-          type: object
-        status:
-          description: SyncedSecretStatus defines the observed state of SyncedSecret
-          properties:
-            currentVersionID:
-              description: this is the version of the secret that is present in k8s secret this should be coming from the local cache
-              type: string
-            generatedSecretHash:
-              description: hash(secret.data) that was generated, used for checking of a Secret has diverged and if it needs reconciling
-              type: string
-          required:
-          - currentVersionID
-          type: object
-      type: object
-  version: v1
-  versions:
-  - name: v1
+                type: array
+              dataFrom:
+                description: DataFrom
+                properties:
+                  secretRef:
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                type: object
+              secretMetadata:
+                description: Secret Metadata
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  creationTimestamp:
+                    format: date-time
+                    type: string
+                  labels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+                type: object
+            type: object
+          status:
+            description: SyncedSecretStatus defines the observed state of SyncedSecret
+            properties:
+              currentVersionID:
+                description: this is the version of the secret that is present in
+                  k8s secret this should be coming from the local cache
+                type: string
+              generatedSecretHash:
+                description: hash(secret.data) that was generated, used for checking
+                  of a Secret has diverged and if it needs reconciling
+                type: string
+            required:
+            - currentVersionID
+            type: object
+        type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
+    subresources:
+      status: {}


### PR DESCRIPTION
The examples are used here https://github.com/contentful/cf-k8s-core-charts/blob/2c90a7c29ec116bcb3deb45b8edd7fbce598cce2/Makefile#L78

Need to update the example to include the new property of AWSAccountID